### PR TITLE
type属性が設定されていない場合かそれに'text/javascript'が設定されている場合だけをeval()の対象にする。

### DIFF
--- a/jquery.pjax.js
+++ b/jquery.pjax.js
@@ -642,7 +642,7 @@
                 jQuery.when.apply( null , executes )
                 .done( function () {
                   for ( var i = 0 , exec ; exec = arguments[ i ] ; i++ ) {
-                    0 < Number( exec.nodeType ) && eval( ( exec.text || exec.textContent || exec.innerHTML || '' ).replace( /^\s*<!(?:\[CDATA\[|\-\-)/ , '/*$0*/' ) ) ; /* */
+                    0 < Number( exec.nodeType ) && ( exec.type === '' ||  exec.type.toLowerCase() === 'text/javascript' ) && eval( ( exec.text || exec.textContent || exec.innerHTML || '' ).replace( /^\s*<!(?:\[CDATA\[|\-\-)/ , '/*$0*/' ) ) ; /* */
                   } ;
                 } ) ;
                 


### PR DESCRIPTION
こんにちは。
jquery.pjax.jsを使わせて頂きたいと思って試行錯誤しています。すばらしい出来栄えに感動しています!

さて、今、jquery.pjax.jsと[Handlebars.js](http://handlebarsjs.com/)と一緒に利用しようとしているのですが、Handlebars.jsはテンプレートを

　　　　＜script type="text/x-handlebars"＞
　　　　＜/script＞

というscriptタグの中に記述可能な仕様となっており、そのため現状、jquery.pjax.jsを　load: { script: true }　を設定して利用すると、この部分が評価されて、

```
Uncaught SyntaxError: Unexpected token ILLEGAL jquery.pjax.js:645
```

というエラーが出るケースがあります。

今回のPRは、これが出ないようにしたものです。
しかし、もっと優れたやり方があるかもしれませんが、参考にして頂ければ幸いです。
よろしくお願いします。
