### PR TITLE
fix: resolve issues under Firefox add-on context

### DIFF
--- a/src/layer/domain/router/model/eav/value/fetch.ts
+++ b/src/layer/domain/router/model/eav/value/fetch.ts
@@ -24,6 +24,6 @@ export class FetchResponse {
     name => this.xhr.getResponseHeader(name);
   public readonly document: Document =
     this.xhr.responseType === 'document'
-      ? this.xhr.responseXML!.cloneNode(true) as Document
+      ? this.xhr.responseXML as Document
       : parse(this.xhr.responseText).extract();
 }

--- a/src/layer/domain/router/module/fetch/xhr.ts
+++ b/src/layer/domain/router/module/fetch/xhr.ts
@@ -32,7 +32,7 @@ export function xhr(
   return new AtomicPromise<Either<Error, FetchResponse>>(resolve => {
     if (key && memory.has(key)) return resolve(Right(memory.get(key)!(displayURL, requestURL)));
     const xhr = new XMLHttpRequest();
-    void xhr.open(method, requestURL.path, true);
+    void xhr.open(method, requestURL.reference, true);
     for (const [name, value] of headers) {
       void xhr.setRequestHeader(name, value);
     }


### PR DESCRIPTION
After #44 , add-ons won't crash during module initialization. However, I encountered other two issues when trying to redirect with pjax-api. Luckily, I managed to solve them by myself.

1. `SyntaxError: The URI is malformed.` - XHR in add-on context need host fragment in URL to work properly.
    ![image](https://user-images.githubusercontent.com/7480839/82919418-95840200-9fa8-11ea-95a6-bf24d76b6c7d.png)

2. `NS_ERROR_UNEXPECTED` - cloning Document failure.
    ![image](https://user-images.githubusercontent.com/7480839/82919630-dbd96100-9fa8-11ea-9fa3-ce14dc31e40e.png)

Please review for any cases I did not take care of.
