### PR TITLE
Added „No jQuery dependency“ into the feature table

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The second generation PJAX for advanced web frameworks.
 |**Scroll position restoration**|**X**|O|**X**|
 |NOSCRIPT tag restoration|X|O|X|
 |History API support<sup>\*2</sup>|?|O|?|
+|No jQuery dependency|X|O|?|
 
 \*1 Excludes ES modules.\
 \*2 You can use pjax APIs and history APIs in combination.


### PR DESCRIPTION
Having jQuery as a dependency is a major downside of the original defunkt/pjax